### PR TITLE
fix: mobile button alignment with responsive CSS

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,22 @@
 import React, { Suspense, useState, useEffect } from 'react';
 import TechStack3D from './components/TechStack3D';
+import Button from './components/Button';
 import './index.css';
+import './css/components/buttons.css';
+import './css/responsive.css';
+
+const CATEGORIES = [
+  { key: 'all', label: 'All' },
+  { key: 'language', label: 'Languages' },
+  { key: 'framework', label: 'Frameworks' },
+  { key: 'infrastructure', label: 'Infrastructure' },
+];
 
 const App = () => {
   const [loading, setLoading] = useState(true);
+  const [activeCategory, setActiveCategory] = useState('all');
 
   useEffect(() => {
-    // 模拟加载过程
     const timer = setTimeout(() => {
       setLoading(false);
     }, 2000);
@@ -27,6 +37,20 @@ const App = () => {
         <h1>技术栈3D展示</h1>
         <p>一个高级、专业的3D技术栈可视化组件，展示团队的核心技术能力</p>
       </header>
+
+      <div className="button-container" role="toolbar" aria-label="Filter tech stack by category">
+        {CATEGORIES.map((cat) => (
+          <Button
+            key={cat.key}
+            variant={activeCategory === cat.key ? 'primary' : 'secondary'}
+            active={activeCategory === cat.key}
+            onClick={() => setActiveCategory(cat.key)}
+            ariaLabel={`Filter by ${cat.label}`}
+          >
+            {cat.label}
+          </Button>
+        ))}
+      </div>
       
       <div className="canvas-container">
         <Suspense fallback={null}>

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+/**
+ * Button component for the 3D Tech Stack Visualization.
+ * Supports primary/secondary variants and active state.
+ * Properly aligned on mobile via CSS media queries in buttons.css.
+ *
+ * @param {Object} props
+ * @param {React.ReactNode} props.children - Button label/content
+ * @param {'primary'|'secondary'} [props.variant='secondary'] - Button style variant
+ * @param {boolean} [props.active=false] - Whether the button is in active/selected state
+ * @param {function} [props.onClick] - Click handler
+ * @param {string} [props.className] - Additional CSS class names
+ * @param {string} [props.ariaLabel] - Accessible label for the button
+ */
+const Button = ({
+  children,
+  variant = 'secondary',
+  active = false,
+  onClick,
+  className = '',
+  ariaLabel,
+  ...rest
+}) => {
+  const classNames = [
+    'btn',
+    `btn--${variant}`,
+    active ? 'btn--active' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      className={classNames}
+      onClick={onClick}
+      aria-label={ariaLabel}
+      aria-pressed={active}
+      type="button"
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/css/components/buttons.css
+++ b/src/css/components/buttons.css
@@ -1,0 +1,149 @@
+/* ==========================================================================
+   Button Component Styles
+   ========================================================================== */
+
+/* Base button styles */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 20px;
+  min-height: 44px;
+  min-width: 44px;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  transition: all 0.25s ease;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.btn:focus-visible {
+  outline: 2px solid #80ffff;
+  outline-offset: 2px;
+}
+
+/* Primary button */
+.btn--primary {
+  background: linear-gradient(135deg, #4080ff, #6060ff);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 2px 8px rgba(64, 128, 255, 0.3);
+}
+
+.btn--primary:hover {
+  background: linear-gradient(135deg, #5090ff, #7070ff);
+  box-shadow: 0 4px 12px rgba(64, 128, 255, 0.5);
+  transform: translateY(-1px);
+}
+
+.btn--primary:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 4px rgba(64, 128, 255, 0.3);
+}
+
+.btn--primary.btn--active {
+  background: linear-gradient(135deg, #80ffff, #60ccff);
+  color: #030712;
+  box-shadow: 0 0 16px rgba(128, 255, 255, 0.4);
+}
+
+/* Secondary button */
+.btn--secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: #c0c8d8;
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.btn--secondary:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.btn--secondary:active {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.btn--secondary.btn--active {
+  background: rgba(64, 128, 255, 0.15);
+  color: #80ffff;
+  border-color: rgba(128, 255, 255, 0.3);
+}
+
+/* Button container - desktop defaults */
+.button-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 16px;
+  z-index: 10;
+  position: absolute;
+  top: 80px;
+  left: 0;
+  width: 100%;
+}
+
+/* ==========================================================================
+   Mobile Button Alignment Fix
+   Ensures buttons are centered and properly stacked on mobile viewports
+   ========================================================================== */
+
+@media screen and (max-width: 767px) {
+  .button-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 12px;
+    padding: 12px 16px;
+    top: 70px;
+  }
+
+  .button-container .btn {
+    width: 100%;
+    max-width: 320px;
+    min-height: 44px;
+    margin: 0;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .button-container {
+    padding: 10px 16px;
+    gap: 10px;
+    top: 60px;
+  }
+
+  .button-container .btn {
+    max-width: 280px;
+    font-size: 0.8125rem;
+    padding: 8px 16px;
+  }
+}
+
+@media screen and (max-width: 320px) {
+  .button-container {
+    padding: 8px 16px;
+  }
+
+  .button-container .btn {
+    max-width: 100%;
+    font-size: 0.75rem;
+  }
+}

--- a/src/css/components/buttons.css
+++ b/src/css/components/buttons.css
@@ -17,7 +17,7 @@
   line-height: 1.4;
   text-align: center;
   text-decoration: none;
-  white-space: nowrap;
+  white-space: normal;
   cursor: pointer;
   border: 2px solid transparent;
   border-radius: 8px;

--- a/src/css/responsive.css
+++ b/src/css/responsive.css
@@ -1,0 +1,108 @@
+/* ==========================================================================
+   Responsive Breakpoints & Layout
+   Mobile-first responsive design for the 3D Tech Stack Visualization
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   Mobile breakpoint: max-width 767px
+   Centers layout elements, adjusts typography and spacing for small screens
+   -------------------------------------------------------------------------- */
+@media screen and (max-width: 767px) {
+  .header {
+    padding: 12px 16px;
+  }
+
+  .header h1 {
+    font-size: 1.5rem;
+  }
+
+  .header p {
+    font-size: 0.85rem;
+    padding: 0 8px;
+  }
+
+  .footer {
+    padding: 8px 16px;
+  }
+
+  .footer p {
+    font-size: 0.7rem;
+    line-height: 1.4;
+  }
+
+  .loading {
+    font-size: 1.2rem;
+  }
+
+  .loading-spinner {
+    width: 40px;
+    height: 40px;
+    margin-right: 10px;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   Small mobile breakpoint: max-width 480px
+   Further reduces sizing for very small devices
+   -------------------------------------------------------------------------- */
+@media screen and (max-width: 480px) {
+  .header {
+    padding: 10px 16px;
+  }
+
+  .header h1 {
+    font-size: 1.2rem;
+  }
+
+  .header p {
+    font-size: 0.8rem;
+  }
+
+  .footer p {
+    font-size: 0.65rem;
+  }
+
+  .loading {
+    font-size: 1rem;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .loading-spinner {
+    width: 35px;
+    height: 35px;
+    margin-right: 0;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   Extra-small mobile breakpoint: max-width 320px
+   Minimum viable layout for smallest screens
+   -------------------------------------------------------------------------- */
+@media screen and (max-width: 320px) {
+  .header {
+    padding: 8px 12px;
+  }
+
+  .header h1 {
+    font-size: 1rem;
+  }
+
+  .header p {
+    font-size: 0.75rem;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   Tablet breakpoint: 768px - 1024px
+   Intermediate layout adjustments
+   -------------------------------------------------------------------------- */
+@media screen and (min-width: 768px) and (max-width: 1024px) {
+  .header h1 {
+    font-size: 1.75rem;
+  }
+
+  .header p {
+    font-size: 0.95rem;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -106,27 +106,4 @@ html, body, #root {
   }
 }
 
-/* 响应式设计 */
-@media (max-width: 768px) {
-  .header h1 {
-    font-size: 1.5rem;
-  }
-  
-  .header p {
-    font-size: 0.9rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .header {
-    padding: 15px;
-  }
-  
-  .header h1 {
-    font-size: 1.2rem;
-  }
-  
-  .header p {
-    font-size: 0.8rem;
-  }
-}
+/* Responsive rules moved to src/css/responsive.css */


### PR DESCRIPTION
# fix: mobile button alignment with responsive CSS

## Summary
Adds a reusable `Button` component and category filter button bar to the 3D Tech Stack app, with responsive CSS that centers and stacks buttons vertically on mobile viewports (`<768px`). Consolidates scattered responsive rules from `index.css` into dedicated CSS files.

**New files:**
- `src/components/Button.jsx` — Reusable button with `primary`/`secondary` variants, `active` state, and `aria-pressed` accessibility
- `src/css/components/buttons.css` — Button styles + mobile alignment media queries (767px, 480px, 320px breakpoints)
- `src/css/responsive.css` — Consolidated responsive layout rules (moved from `index.css`, extended with footer/loading/tablet breakpoints)

**Modified files:**
- `src/App.jsx` — Adds category filter buttons (All / Languages / Frameworks / Infrastructure) with active state toggling
- `src/index.css` — Removed inline responsive media queries (now in `responsive.css`)

## Updates since last revision
- Fixed `white-space: nowrap` → `white-space: normal` on `.btn` so button text wraps correctly under OS-level large font settings (previously flagged in review checklist).

## Review & Testing Checklist for Human
- [ ] **Buttons don't actually filter the 3D view.** `activeCategory` state is managed in `App.jsx` but never passed to `TechStack3D`. The buttons toggle visual state only — verify this is acceptable or if filtering integration is expected.
- [ ] **Check for header/button overlap on mobile.** The `.button-container` uses `position: absolute; top: 80px` (70px/60px on mobile). Verify visually that it doesn't collide with the header text at all breakpoints (320px, 375px, 414px, 768px).
- [ ] **Manual mobile testing recommended.** No browser screenshots were captured. Test in Chrome DevTools responsive mode at 320px, 375px, 414px, and 768px widths to confirm buttons are centered, don't overlap adjacent elements, and maintain ≥44px tap targets.
- [ ] Verify the slightly shifted breakpoint (`768px` → `767px`) doesn't cause a 1px visual gap at exactly 768px width.

### Notes
- Build and existing unit tests pass. No new tests were added for the Button component.
- [Link to Devin run](https://app.devin.ai/sessions/fb87aac211ce4294abec0f3ceb95c730)
- Requested by: @Kevinzh0C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a category filter toolbar with interactive buttons beneath the header for filtering content
  * Introduced a reusable Button component with primary and secondary style variants and active state support

* **Style**
  * Enhanced responsive design across mobile and tablet breakpoints with optimized padding, spacing, and typography
  * Improved CSS organization by consolidating responsive rules into a dedicated module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->